### PR TITLE
Enhance Curios support and increment build version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ repositories {
     mavenLocal()
 }
 
-version = "1.20.02"
+version = "1.20.03"
 group = "dev.gigaherz.toolbelt"
 archivesBaseName = "ToolBelt-UNKNOWN"
 

--- a/src/main/java/dev/gigaherz/toolbelt/BeltFinder.java
+++ b/src/main/java/dev/gigaherz/toolbelt/BeltFinder.java
@@ -19,6 +19,11 @@ public abstract class BeltFinder
         instances.add(0, finder);
     }
 
+    public static synchronized boolean isFinderRegistered(String name)
+    {
+        return instances.stream().anyMatch(f -> f.getName().equals(name));
+    }
+
     public static Optional<? extends BeltGetter> findBelt(LivingEntity player)
     {
         return findBelt(player, false);

--- a/src/main/java/dev/gigaherz/toolbelt/ToolBelt.java
+++ b/src/main/java/dev/gigaherz/toolbelt/ToolBelt.java
@@ -191,7 +191,22 @@ public class ToolBelt
 
         BeltExtensionSlot.register();
         BeltFinderBeltSlot.initBaubles();
-        CURIOS.addListener(cap -> BeltFinderCurios.initCurios());
+        
+        // Initialize Curios support directly if the mod is loaded
+        // This ensures compatibility with Accessories mod's Curios compatibility layer
+        if (ModList.get().isLoaded("curios"))
+        {
+            BeltFinderCurios.initCurios();
+        }
+        
+        // Keep capability listener as a fallback for alternate initialization paths
+        CURIOS.addListener(cap -> {
+            // Only initialize if not already registered to prevent duplicates
+            if (!BeltFinder.isFinderRegistered("curios"))
+            {
+                BeltFinderCurios.initCurios();
+            }
+        });
     }
 
     private static final Capability<ICuriosItemHandler> CURIOS = CapabilityManager.get(new CapabilityToken<>()


### PR DESCRIPTION
Improve the initialization of Curios support in ToolBelt for better compatibility with the Accessories Curios Compat Layer. Update the build version to reflect these changes.

Prior to these changes ToolBelt would not detect the use of `Curios Compat Layer for Accessories` which acts as a drop-in replacing Curios for Accessories support and as such, the keybind could not be triggered for Swap Tool when the toolbelt was in the Accessories belt slot.