### PR TITLE
Ability for Consumers to Add Custom Toolbelt Textures

### DIFF
--- a/src/main/java/dev/gigaherz/toolbelt/client/ClientEvents.java
+++ b/src/main/java/dev/gigaherz/toolbelt/client/ClientEvents.java
@@ -11,13 +11,13 @@ import net.minecraft.client.Options;
 import net.minecraft.client.model.EntityModel;
 import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.client.model.geom.ModelLayerLocation;
-import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.player.Input;
 import net.minecraft.client.renderer.entity.EntityRenderer;
 import net.minecraft.client.renderer.entity.LivingEntityRenderer;
 import net.minecraft.client.renderer.entity.layers.RenderLayer;
-import net.minecraft.client.renderer.item.ItemProperties;
 import net.minecraft.client.resources.PlayerSkin;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.client.resources.model.ModelResourceLocation;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.EntityType;
@@ -27,12 +27,13 @@ import net.minecraft.world.item.ItemStack;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
-import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
 import net.neoforged.neoforge.client.event.*;
 import net.neoforged.neoforge.network.PacketDistributor;
 import org.jetbrains.annotations.Nullable;
 import org.lwjgl.glfw.GLFW;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Function;
 
 @EventBusSubscriber(value = Dist.CLIENT, modid = ToolBelt.MODID, bus = EventBusSubscriber.Bus.GAME)
@@ -167,15 +168,46 @@ public class ClientEvents
         }
 
         @SubscribeEvent
-        public static void clientSetup(FMLClientSetupEvent event)
+        public static void registerAdditionalModels(ModelEvent.RegisterAdditional event)
         {
-            event.enqueueWork(() -> {
-                ItemProperties.register(ToolBelt.BELT.get(), ToolBelt.location("has_custom_color"),
-                        (ItemStack pStack, @Nullable ClientLevel pLevel, @Nullable LivingEntity pEntity, int pSeed) ->
-                                pStack.has(DataComponents.DYED_COLOR)
-                                        ? 1 : 0
-                );
-            });
+            var rm = Minecraft.getInstance().getResourceManager();
+
+            event.register(ModelResourceLocation.standalone(ToolBelt.location("item/dyed_belt")));
+
+            for (int i = 2; i <= 9; i++) {
+                if (rm.getResource(ToolBelt.location("models/item/belt_" + i + ".json")).isPresent()
+                        && rm.getResource(ToolBelt.location("textures/item/belt_" + i + ".png")).isPresent())
+                    event.register(ModelResourceLocation.standalone(ToolBelt.location("item/belt_" + i)));
+
+                if (rm.getResource(ToolBelt.location("models/item/belt_" + i + "_dyed.json")).isPresent()
+                        && rm.getResource(ToolBelt.location("textures/item/belt_" + i + "_dyed.png")).isPresent())
+                    event.register(ModelResourceLocation.standalone(ToolBelt.location("item/belt_" + i + "_dyed")));
+            }
+        }
+
+        @SubscribeEvent
+        public static void modifyBakingResult(ModelEvent.ModifyBakingResult event)
+        {
+            Map<ModelResourceLocation, BakedModel> models = event.getModels();
+
+            ModelResourceLocation beltKey = ModelResourceLocation.inventory(ToolBelt.location("belt"));
+            BakedModel baseModel = models.get(beltKey);
+            if (baseModel == null) {
+                return;
+            }
+
+            Map<Integer, BakedModel> tierModels = new HashMap<>();
+            Map<Integer, BakedModel> tierDyedModels = new HashMap<>();
+            for (int i = 2; i <= 9; i++) {
+                BakedModel tier = models.get(ModelResourceLocation.standalone(ToolBelt.location("item/belt_" + i)));
+                if (tier != null) tierModels.put(i, tier);
+                BakedModel dyedTier = models.get(ModelResourceLocation.standalone(ToolBelt.location("item/belt_" + i + "_dyed")));
+                if (dyedTier != null) tierDyedModels.put(i, dyedTier);
+            }
+
+            BakedModel dyedBase = models.get(ModelResourceLocation.standalone(ToolBelt.location("item/dyed_belt")));
+
+            models.put(beltKey, new DynamicBeltModel(baseModel, tierModels, tierDyedModels, dyedBase));
         }
 
         @SubscribeEvent

--- a/src/main/java/dev/gigaherz/toolbelt/client/DynamicBeltModel.java
+++ b/src/main/java/dev/gigaherz/toolbelt/client/DynamicBeltModel.java
@@ -1,0 +1,62 @@
+package dev.gigaherz.toolbelt.client;
+
+import dev.gigaherz.toolbelt.belt.ToolBeltItem;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.renderer.block.model.ItemOverrides;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.neoforge.client.model.BakedModelWrapper;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+import java.util.Map;
+
+public class DynamicBeltModel extends BakedModelWrapper<BakedModel> {
+    private final Map<Integer, BakedModel> tierModels;
+    private final Map<Integer, BakedModel> tierDyedModels;
+    @Nullable private final BakedModel dyedBaseModel;
+    private final ItemOverrides overrides;
+
+    public DynamicBeltModel(BakedModel base, Map<Integer, BakedModel> tierModels,
+                            Map<Integer, BakedModel> tierDyedModels, @Nullable BakedModel dyedBaseModel) {
+        super(base);
+        this.tierModels = tierModels;
+        this.tierDyedModels = tierDyedModels;
+        this.dyedBaseModel = dyedBaseModel;
+        this.overrides = new ItemOverrides() {
+            @Override
+            public @Nullable BakedModel resolve(BakedModel model, ItemStack stack, @Nullable ClientLevel level, @Nullable LivingEntity entity, int seed) {
+                return resolveModel(stack);
+            }
+        };
+    }
+
+    @Override
+    public ItemOverrides getOverrides() {
+        return overrides;
+    }
+
+    @Override
+    public List<BakedModel> getRenderPasses(ItemStack itemStack, boolean fabulous) {
+        return resolveModel(itemStack).getRenderPasses(itemStack, fabulous);
+    }
+
+    private BakedModel resolveModel(ItemStack stack) {
+        int slots = ToolBeltItem.getSlotsCount(stack);
+        boolean dyed = stack.has(DataComponents.DYED_COLOR);
+
+        if (dyed) {
+            BakedModel dyedTier = tierDyedModels.get(slots);
+            if (dyedTier != null) return dyedTier;
+            if (dyedBaseModel != null) return dyedBaseModel;
+        }
+
+        BakedModel tier = tierModels.get(slots);
+        if (tier != null) return tier;
+
+        return originalModel;
+    }
+}

--- a/src/main/java/dev/gigaherz/toolbelt/client/ToolBeltLayer.java
+++ b/src/main/java/dev/gigaherz/toolbelt/client/ToolBeltLayer.java
@@ -6,6 +6,7 @@ import com.mojang.math.Axis;
 import dev.gigaherz.toolbelt.BeltFinder;
 import dev.gigaherz.toolbelt.ConfigData;
 import dev.gigaherz.toolbelt.ToolBelt;
+import dev.gigaherz.toolbelt.belt.ToolBeltItem;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.EntityModel;
 import net.minecraft.client.model.HumanoidModel;
@@ -29,10 +30,24 @@ import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.capabilities.Capabilities;
 
+
 public class ToolBeltLayer<T extends LivingEntity, M extends HumanoidModel<T>> extends RenderLayer<T, M>
 {
     private static final ResourceLocation TEXTURE_BELT = ToolBelt.location("textures/entity/belt.png");
     private static final ResourceLocation TEXTURE_BELT_DYED = ToolBelt.location("textures/entity/dyed_belt.png");
+
+    private static ResourceLocation resolveTexture(int slots, boolean dyed)
+    {
+        var rm = Minecraft.getInstance().getResourceManager();
+        if (dyed) {
+            var dyedCandidate = ToolBelt.location("textures/entity/belt_" + slots + "_dyed.png");
+            if (rm.getResource(dyedCandidate).isPresent())
+                return dyedCandidate;
+            return TEXTURE_BELT_DYED;
+        }
+        var candidate = ToolBelt.location("textures/entity/belt_" + slots + ".png");
+        return rm.getResource(candidate).isPresent() ? candidate : TEXTURE_BELT;
+    }
 
     private static ItemDisplayContext LEFTSIDE = Enum.valueOf(ItemDisplayContext.class, "TOOLBELT_LEFTSIDE");
     private static ItemDisplayContext RIGHTSIDE = Enum.valueOf(ItemDisplayContext.class, "TOOLBELT_RIGHTSIDE");
@@ -143,9 +158,9 @@ public class ToolBeltLayer<T extends LivingEntity, M extends HumanoidModel<T>> e
     {
         return BeltFinder.findBelt(pEntity, true).map((getter) -> {
             var stack = getter.getBelt();
-            return stack.has(DataComponents.DYED_COLOR)
-                    ? TEXTURE_BELT_DYED
-                    : TEXTURE_BELT;
+            int slots = ToolBeltItem.getSlotsCount(stack);
+            boolean dyed = stack.has(DataComponents.DYED_COLOR);
+            return resolveTexture(slots, dyed);
         }).orElse(TEXTURE_BELT);
     }
 
@@ -200,7 +215,7 @@ public class ToolBeltLayer<T extends LivingEntity, M extends HumanoidModel<T>> e
 
             if (hasColor)
             {
-                var dye = FastColor.ARGB32.colorFromFloat(dyeRed, dyeGreen, dyeBlue, 1.0f);
+                var dye = FastColor.ARGB32.colorFromFloat(1.0f, dyeRed, dyeGreen, dyeBlue);
                 color2 = FastColor.ARGB32.multiply(color, dye);
             }
 

--- a/src/main/resources/assets/toolbelt/models/item/belt.json
+++ b/src/main/resources/assets/toolbelt/models/item/belt.json
@@ -3,13 +3,5 @@
   "textures": {
     "layer0": "toolbelt:item/belt",
     "layer1": "toolbelt:item/belt_buckle"
-  },
-  "overrides": [
-    {
-      "predicate": {
-        "toolbelt:has_custom_color": 1
-      },
-      "model": "toolbelt:item/dyed_belt"
-    }
-  ]
+  }
 }


### PR DESCRIPTION
Condition: models/item/belt_N.json AND textures/item/belt_N.png must both be present for the plain tier model to register. Same pairing applies for dyed (belt_N_dyed.json + textures/item/belt_N_dyed.png).

  Typical model content — plain:
  { "parent": "item/generated", "textures": { "layer0": "toolbelt:item/belt_N", "layer1": "toolbelt:item/belt_N_buckle" } }
  Dyed (layer0 is the tintable grayscale texture, layer1 buckle is untinted):
  { "parent": "item/generated", "textures": { "layer0": "toolbelt:item/belt_N_dyed", "layer1": "toolbelt:item/belt_N_buckle" } }

  Item textures:

  textures/item/belt_N.png         – plain belt texture
  textures/item/belt_N_dyed.png    – grayscale texture; gets multiplied by the dye colour at runtime
  textures/item/belt_N_buckle.png  – buckle overlay (not tinted)

  Entity textures:

  Controls the belt rendered on the player/mob body. Each is probed independently — missing files fall back gracefully.

  textures/entity/belt_N.png       – plain entity texture for N-slot belt
  textures/entity/belt_N_dyed.png  – dyed entity texture for N-slot belt

  Fallback chain (entity):
  - Dyed belt: tries belt_N_dyed.png → falls back to dyed_belt.png (built-in)
  - Plain belt: tries belt_N.png → falls back to belt.png (built-in)